### PR TITLE
Imgui enabled macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.15)
 
 project(storytime)
 
+option(STORYTIME_EDITOR "Run with editor UI" OFF)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -169,6 +171,11 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 # Precompiled header
 target_include_directories(${PROJECT_NAME} PUBLIC ${STORYTIME_SRC_DIR})
 target_precompile_headers(${PROJECT_NAME} PUBLIC ${STORYTIME_SRC_DIR}/st_pch.h)
+
+# Preprocessor macros
+if (${STORYTIME_EDITOR})
+    target_compile_definitions(${PROJECT_NAME} PRIVATE ST_IMGUI_ENABLED)
+endif ()
 
 # --------------------------------------------------------------------------------------------------------------
 # Custom targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.15)
 
 project(storytime)
 
-option(STORYTIME_EDITOR "Run with editor UI" OFF)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -171,11 +169,6 @@ target_include_directories(${PROJECT_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include)
 # Precompiled header
 target_include_directories(${PROJECT_NAME} PUBLIC ${STORYTIME_SRC_DIR})
 target_precompile_headers(${PROJECT_NAME} PUBLIC ${STORYTIME_SRC_DIR}/st_pch.h)
-
-# Preprocessor macros
-if (${STORYTIME_EDITOR})
-    target_compile_definitions(${PROJECT_NAME} PRIVATE ST_IMGUI_ENABLED)
-endif ()
 
 # --------------------------------------------------------------------------------------------------------------
 # Custom targets

--- a/include/storytime/storytime.h
+++ b/include/storytime/storytime.h
@@ -21,10 +21,12 @@
 // Graphics
 #include "graphics/bitmap_font.h"
 #include "graphics/camera.h"
-#include "graphics/imgui_renderer.h"
-#include "graphics/imgui_window_event.h"
 #include "graphics/spritesheet.h"
 #include "graphics/view_projection.h"
+#ifdef ST_IMGUI_ENABLED
+    #include "graphics/imgui_renderer.h"
+    #include "graphics/imgui_window_event.h"
+#endif
 
 // Resource
 #include "resource/resource_loader.h"

--- a/src/graphics/bitmap_font.cpp
+++ b/src/graphics/bitmap_font.cpp
@@ -1,26 +1,26 @@
 #include "bitmap_font.h"
 
 namespace Storytime {
-    BitmapFont::BitmapFont(BitmapFontConfig config) : config(std::move(config)) {}
+    BitmapFont::BitmapFont(const BitmapFontConfig& config) : config(config) {}
 
-    void BitmapFont::render_text(const std::string& text, const BitmapTextConfig& text_config) {
-        float factor = 5.0f;
-
-        float gw = 6.0f * factor;
-        float gh = 12.0f * factor;
-        float ts = config.texture->get_width() * factor;
+    void BitmapFont::render_text(const std::string& text, const BitmapTextConfig& text_config) const {
+        float gw = config.glyph_width;
+        float gh = config.glyph_height;
+        float ts = config.texture->get_width();
 
         f32 size_x = text_config.font_size * (gw / gh);
         f32 size_y = text_config.font_size;
 
         glm::vec3 position = text_config.position;
+        position.x += size_x / 2;
+        position.y += size_y / 2;
 
         for (int i = 0; i < text.size(); ++i) {
             const char value = text[i];
 
             if (value == '\n') {
                 position.y += size_y;
-                position.x = text_config.position.x;
+                position.x = text_config.position.x + size_x / 2;
                 continue;
             }
 
@@ -46,6 +46,14 @@ namespace Storytime {
             c[1] = {xbt, yat};
             c[2] = {xbt, ybt};
             c[3] = {xat, ybt};
+
+            if (text_config.debug) {
+                Quad debug_quad;
+                debug_quad.color = { (f32) i, (f32) i, (f32) i, 0.5f };
+                debug_quad.size = {size_x, size_y};
+                debug_quad.position = position;
+                config.renderer->render_quad(debug_quad);
+            }
 
             Quad quad;
             quad.texture = config.texture;

--- a/src/graphics/bitmap_font.h
+++ b/src/graphics/bitmap_font.h
@@ -15,6 +15,7 @@ namespace Storytime {
     struct BitmapTextConfig {
         glm::vec3 position = { 0.0f, 0.0f, 0.0f };
         f32 font_size = 0.0f;
+        bool debug = false;
     };
 
     class BitmapFont {
@@ -22,8 +23,8 @@ namespace Storytime {
         BitmapFontConfig config;
 
     public:
-        explicit BitmapFont(BitmapFontConfig config);
+        BitmapFont(const BitmapFontConfig& config);
 
-        void render_text(const std::string& text, const BitmapTextConfig& text_config = {});
+        void render_text(const std::string& text, const BitmapTextConfig& text_config = {}) const;
     };
 }

--- a/src/graphics/imgui_renderer.h
+++ b/src/graphics/imgui_renderer.h
@@ -4,6 +4,8 @@
 #include "system/game_loop_statistics.h"
 #include "window/window.h"
 
+#include <imgui.h>
+
 namespace Storytime {
     struct ImGuiRendererConfig {
         std::string glsl_version;

--- a/src/st_main.cpp
+++ b/src/st_main.cpp
@@ -13,10 +13,6 @@
 #include "window/window.h"
 #include "window/window_event.h"
 
-#ifdef ST_DEBUG
-    #define ST_RENDER_IMGUI
-#endif
-
 extern "C" void on_create(const Storytime::Storytime&);
 
 extern "C" void on_update(f64 timestep);
@@ -109,7 +105,7 @@ namespace Storytime {
             );
             service_locator.set<Renderer>(&renderer);
 
-#ifdef ST_RENDER_IMGUI
+#ifdef ST_IMGUI_ENABLED
             ImGuiRenderer imgui_renderer({
                 .glsl_version = config.glsl_version,
                 .window = &window,
@@ -223,7 +219,7 @@ namespace Storytime {
                 // RENDER
                 //
 
-#ifdef ST_RENDER_IMGUI
+#ifdef ST_IMGUI_ENABLED
                 imgui_framebuffer.bind();
 #endif
 
@@ -233,7 +229,7 @@ namespace Storytime {
                 renderer.end_frame();
                 TimePoint render_end_time = Time::now();
 
-#ifdef ST_RENDER_IMGUI
+#ifdef ST_IMGUI_ENABLED
                 imgui_framebuffer.unbind();
 
                 TimePoint imgui_render_start_time = Time::now();
@@ -261,7 +257,7 @@ namespace Storytime {
                 }
                 game_loop_stats.render_duration_ms = Time::as<Microseconds>(render_end_time - render_start_time).count() / 1000.0;
                 game_loop_stats.frames_per_second = 1.0 / (game_loop_stats.render_duration_ms / 1000.0);
-#ifdef ST_RENDER_IMGUI
+#ifdef ST_IMGUI_ENABLED
                 game_loop_stats.imgui_render_duration_ms = Time::as<Microseconds>(imgui_render_end_time - imgui_render_start_time).count() / 1000.0;
 #endif
                 game_loop_stats.window_events_duration_ms = Time::as<Microseconds>(window_event_end_time - window_event_start_time).count() / 1000.0;

--- a/src/st_main.cpp
+++ b/src/st_main.cpp
@@ -3,8 +3,6 @@
 #include "resource/resource_loader.h"
 #include "graphics/open_gl.h"
 #include "graphics/renderer.h"
-#include "graphics/imgui_renderer.h"
-#include "graphics/imgui_window_event.h"
 #include "system/clock.h"
 #include "system/event_manager.h"
 #include "system/file_reader.h"
@@ -13,15 +11,22 @@
 #include "window/window.h"
 #include "window/window_event.h"
 
+#ifdef ST_IMGUI_ENABLED
+    #include "graphics/imgui_renderer.h"
+    #include "graphics/imgui_window_event.h"
+#endif
+
 extern "C" void on_create(const Storytime::Storytime&);
 
 extern "C" void on_update(f64 timestep);
 
 extern "C" void on_render();
 
-extern "C" void on_render_imgui();
-
 extern "C" void on_destroy();
+
+#ifdef ST_IMGUI_ENABLED
+    extern "C" void on_render_imgui();
+#endif
 
 namespace Storytime {
     static bool running = false;
@@ -264,6 +269,8 @@ namespace Storytime {
                 game_loop_stats.game_events_duration_ms = Time::as<Microseconds>(game_event_end_time - game_event_start_time).count() / 1000.0;
                 game_loop_stats.swap_buffers_duration_ms = Time::as<Microseconds>(swap_buffers_end_time - swap_buffers_start_time).count() / 1000.0;
                 game_loop_stats.cycle_duration_ms = Time::as<Microseconds>(cycle_end_time - cycle_start_time).count() / 1000.0;
+
+                event_manager.trigger_event_silent(GameLoopStatisticsEvent::type, GameLoopStatisticsEvent(game_loop_stats));
             }
 
             ST_LOG_INFO("Terminating...");

--- a/src/st_pch.h
+++ b/src/st_pch.h
@@ -54,6 +54,7 @@
 #include "system/memory.h"
 #include "system/numbers.h"
 #include "system/pointers.h"
+#include "system/random.h"
 #include "system/utils.h"
 
 // Script

--- a/src/st_pch.h
+++ b/src/st_pch.h
@@ -38,10 +38,6 @@
 #include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/rotate_vector.hpp>
 
-// ImGui
-#include <imgui.h>
-#include <imgui_internal.h>
-
 // Lua
 #include <lua.hpp>
 

--- a/src/system/command_line_arguments.cpp
+++ b/src/system/command_line_arguments.cpp
@@ -18,4 +18,15 @@ namespace Storytime {
         }
         return false;
     }
+
+    std::ostream& operator<<(std::ostream& os, const CommandLineArguments& arguments) {
+        os << "Args:" << std::endl;
+        for (int i = 0; i < arguments.count; ++i) {
+            os << "[" << i << "] " << arguments.args[i];
+            if (i < arguments.count - 1) {
+                os << std::endl;
+            }
+        }
+        return os;
+    }
 }

--- a/src/system/command_line_arguments.h
+++ b/src/system/command_line_arguments.h
@@ -14,4 +14,6 @@ namespace Storytime {
 
         bool exists(const char* key) const;
     };
+
+    std::ostream& operator<<(std::ostream& os, const CommandLineArguments& arguments);
 }

--- a/src/system/event_manager.h
+++ b/src/system/event_manager.h
@@ -20,7 +20,7 @@ namespace Storytime {
         typedef std::vector<EventQueue> EventQueueList;
 
     private:
-        static u32 subscription_counter;
+        static u32 next_subscription_id;
 
     private:
         EventManagerConfig config;
@@ -41,7 +41,9 @@ namespace Storytime {
 
         bool unsubscribe_and_clear(std::vector<SubscriptionID>& subscriptions);
 
-        bool trigger_event(EventType event_type, const Event& event);
+        bool trigger_event(EventType event_type, const Event& event, bool silent = false);
+
+        bool trigger_event_silent(EventType event_type, const Event& event);
 
         void queue_event(EventType event_type, const Shared<Event>& event);
 

--- a/src/system/game_loop_statistics.h
+++ b/src/system/game_loop_statistics.h
@@ -6,15 +6,14 @@ namespace Storytime {
     struct GameLoopStatistics {
         f64 cycle_duration_ms = 0.0;
         f64 frames_per_second = 0.0;
+        f64 game_events_duration_ms = 0.0;
         f64 imgui_render_duration_ms = 0.0;
         f64 render_duration_ms = 0.0;
-        f64 update_duration_ms = 0.0;
-        f64 updates_per_second = 0.0;
-        f64 update_timestep_ms = 0.0;
-
-        f64 window_events_duration_ms = 0.0;
         f64 swap_buffers_duration_ms = 0.0;
-        f64 game_events_duration_ms = 0.0;
+        f64 update_duration_ms = 0.0;
+        f64 update_timestep_ms = 0.0;
+        f64 updates_per_second = 0.0;
+        f64 window_events_duration_ms = 0.0;
     };
 
     struct GameLoopStatisticsEvent : Event {

--- a/src/window/window.cpp
+++ b/src/window/window.cpp
@@ -95,9 +95,9 @@ namespace Storytime {
         return (f32) width / (f32) height;
     }
 
+    // Returns the time elapsed, in seconds, since GLFW was initialized, or zero if an error occurred.
+    // The resolution is system dependent.
     f64 Window::get_time() {
-        // Returns the time elapsed, in seconds, since GLFW was initialized, or zero if an error occurred.
-        // The resolution is system dependent.
         return glfwGetTime();
     }
 
@@ -156,7 +156,6 @@ namespace Storytime {
     }
 
     void Window::on_event(GLFWwindow* glfw_window, EventType event_type, const Event& event) {
-        ST_LOG_TRACE(event.to_string());
         auto window = static_cast<Window*>(glfwGetWindowUserPointer(glfw_window));
         ST_ASSERT(window != nullptr, "Invalid GLFW user pointer: Window object must exist when sending events");
         auto event_manager = window->config.event_manager;


### PR DESCRIPTION
- [x] Added `ST_IMGUI_ENABLED` macro that, when defined, will include ImGui code and call the `on_render_imgui` extern function. This is intended to let clients separate pure game builds and development/editor/debug ui builds.

- [x] Misc updates and refactors